### PR TITLE
Stop using hardcoded and outdated root DNSSEC key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ MAINTAINER Jonas Wielicki <jonas@wielicki.name>
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y --no-install-suggests lua5.1 mercurial build-essential git lua5.1-dev libz-dev libunbound-dev lua-dbi-postgresql libidn11-dev lua-socket libunbound2 luajit wget lua-expat python-twisted
+RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y --no-install-suggests lua5.1 mercurial build-essential git lua5.1-dev libz-dev libunbound-dev lua-dbi-postgresql libidn11-dev lua-socket libunbound2 luajit wget lua-expat python-twisted dns-root-data
 
 WORKDIR /opt
 COPY . xmppoke/
 WORKDIR /opt/xmppoke/
-RUN git clone https://github.com/xnyhps/luasec.git && cd luasec && git checkout 64bebd9c9283ce11dfa60945938d0a529861d824 && cd ..
-RUN hg clone http://code.zash.se/luaunbound/ && cd luaunbound && hg update -r b4b293593d0ef64d623a54a8b8d2c1dea4c5e870 && cd .. 
+RUN git clone https://github.com/xnyhps/luasec.git  && cd luasec && git checkout 64bebd9c9283ce11dfa60945938d0a529861d824 && cd ..
+RUN hg clone http://code.zash.se/luaunbound/ && cd luaunbound && hg update -r 8356eb09ebaa && cd ..
 WORKDIR /opt/
 RUN hg clone http://code.matthewwild.co.uk/verse/
 RUN mkdir xmppoke/util
@@ -17,7 +17,7 @@ RUN hg clone http://code.matthewwild.co.uk/squish/ && cd squish && make && make 
 RUN git clone https://github.com/PeterMosmans/openssl --depth 1 && cd openssl && ./config --prefix=/usr/local/ --openssldir=/etc/ssl enable-zlib enable-ssl2 enable-rc5 enable-rc2 enable-GOST enable-cms enable-md2 enable-mdc2 enable-ec enable-ec2m enable-ecdh enable-ecdsa enable-seed enable-camellia enable-idea enable-rfc3779 enable-ec_nistp_64_gcc_128 experimental-jpake shared -DOPENSSL_USE_BUILD_DATE && make depend && make && make install && cd .. && rm -rf openssl
 RUN hg clone https://hg.prosody.im/0.9/ prosody && cd prosody && ./configure --with-lua-include=/usr/include/lua5.1 && make && cp util/encodings.so util/hashes.so ../xmppoke/util/ && cd .. && rm prosody -rf
 RUN cd xmppoke/luasec && make "INC_PATH=-I/opt/local/include -I/usr/include -I/usr/local/include -I/usr/include/lua5.1" linux && make LUACPATH=/usr/local/lib/lua/5.1 LUAPATH=/usr/local/share/lua/5.1 install
-RUN cd xmppoke/luaunbound && CFLAGS=-I/usr/include/lua5.1 make && make LUA_LIBDIR=/usr/local/lib/lua/5.1/ install && cp lunbound.so ../util/
+RUN cd xmppoke/luaunbound && make -B LUA_VERSION=5.1 CFLAGS='-fPIC -I/usr/include/lua5.1 -DIANA_ROOT_TA_FILE=\"/usr/share/dns/root.ds\"' && cp lunbound.so ../
 RUN cd verse && ./configure && make && make install
 RUN ln -s /opt/verse /usr/local/share/lua/5.1/
 RUN cd xmppoke && sed -ri '/local proxy_port/s/9150/9050/;/settimeout/s/5/10/' onions.lua && squish --use-http --no-minify --debug && sed -ri '1s/^(.*)$/_G.socket = require"socket"\n\1/' xmppoke.lua

--- a/squishy
+++ b/squishy
@@ -3,7 +3,7 @@ Output "xmppoke.lua"
 Module "core.configmanager" "configmanager.lua"
 Module "onions" "onions.lua"
 
-AutoFetchURL "http://code.zash.se/luaunbound/raw-file/b4b293593d0e/?"
+AutoFetchURL "https://code.zash.se/luaunbound-prosody/raw-file/81ae4f6fa79c/?"
 
 Module "net.adns" "net.unbound.lua"
 Module "util.dns" "util.dns.lua"


### PR DESCRIPTION
This intends to re-enable DNS SEC testing, and is a fix for https://github.com/xmpp-observatory/xmppoke/issues/4